### PR TITLE
Update facet to 0.29

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [fasterthanlime]
+patreon: fasterthanlime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -47,7 +47,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -68,7 +68,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -92,7 +92,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -111,7 +111,7 @@ jobs:
     container:
       image: ghcr.io/facet-rs/facet-ci:latest-amd64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 
@@ -128,7 +128,7 @@ jobs:
     permissions:
       security-events: write # to upload sarif results
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3290e0be77e9eeca366489c3b4010764dc897a83e5936a93857c3937f47a57aa"
+checksum = "c47b7ae49fd26ee306c81aa350375f16830946729a2339d51fde6a660a210946"
 dependencies = [
  "facet-core",
  "facet-macros",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8643770dc61323e6ae5620f336f4c4fc283a6bf39e6701fed32efa747fba5a6a"
+checksum = "9f448a18de9f8f180a0154dba3ca6ba36174f6f666c17bf94bc98df00e48bd47"
 dependencies = [
  "bitflags",
  "impls",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb526288148251e984f3a9ab3cef5191ca1da34a45fb5c548781e7053148e19"
+checksum = "d726fb66effa4ef614ec0cd55828e5527ac4ed2efdfb3344e84048348e8c5cfe"
 dependencies = [
  "facet-core",
  "facet-macros-emit",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-emit"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52619b4834e81068fd915795c297e52f894a18742581627568d451e39dd1c906"
+checksum = "b3c8d5653543879fb9357b5ce45599a5f456e3225cedcb14f9b3d3d96dc1fe61"
 dependencies = [
  "facet-macros-parse",
  "quote",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-parse"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6097c15775794dd66eb69cd4614be654877e3e6e4a93ca0d0440236c1798f0b"
+checksum = "9f775c1ed593adacc14d224aacedb0a633d0baab8a0107d9e61da53c8ba97736"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -122,20 +122,19 @@ dependencies = [
 
 [[package]]
 name = "facet-reflect"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d24ca6fb9db79b26cb5e37d744591d710e05922dbca7c53505113151b50aef"
+checksum = "b19421a5caf7eb6a04d41fe4b1438aa24689c3ca155bfe3e81368955c0b53d30"
 dependencies = [
  "bitflags",
  "facet-core",
- "owo-colors",
 ]
 
 [[package]]
 name = "facet-serialize"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2724e50a1f41f9f0d3a035b9dd8ef4d174f2c3bfd7caaab4baeb6d69feed9"
+checksum = "8120d560b46dca40232f62fac58c9d986449dbf8b7f41f7aee71322fc09f93a1"
 dependencies = [
  "facet-core",
  "facet-reflect",
@@ -144,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d754d1d685cb364da2c7ffead1c10f4fdb1573653efed0ae1fe8edea20da6c37"
+checksum = "ba9eca2339caf41b8ad453aedd490dbec62df04df159496db400cab796e32ce9"
 dependencies = [
  "color-backtrace",
  "facet-testhelpers-macros",
@@ -156,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "facet-testhelpers-macros"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2202a62fd9bcb98cdef3896393b8886d3341e56bcc69cb4142c436298861b901"
+checksum = "5f9a8e7044c1b922568e4061d6f3ee1bd391d053f11c371db348a0a6b649cbed"
 dependencies = [
  "quote",
  "unsynn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ num-traits = { version = "0.2.19", default-features = false }
 toml_edit = { version = "0.22.27", default-features = false, features = [
     "parse",
 ], optional = true }
-facet-core = { version = "0.28", default-features = false }
-facet-reflect = { version = "0.28", default-features = false }
-facet-serialize = { version = "0.28", default-features = false, optional = true }
+facet-core = { version = "0.29", default-features = false }
+facet-reflect = { version = "0.29", default-features = false }
+facet-serialize = { version = "0.29", default-features = false, optional = true }
 owo-colors = "4.2.2"
 
 [dev-dependencies]
@@ -40,5 +40,5 @@ cargo-husky = { version = "1.5.0", default-features = false, features = [
     "user-hooks",
 ] }
 eyre = "0.6.12"
-facet = { version = "0.28" }
-facet-testhelpers = { version = "0.28" }
+facet = { version = "0.29" }
+facet-testhelpers = { version = "0.29" }

--- a/README.md
+++ b/README.md
@@ -1,36 +1,35 @@
-<h1>
-<picture>
-    <source type="image/webp" media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-dark.webp">
-    <source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-dark.png">
-    <source type="image/webp" srcset="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-light.webp">
-    <img src="https://github.com/facet-rs/facet/raw/main/static/logo-v2/facet-b-light.png" height="35" alt="Facet logo - a reflection library for Rust">
-</picture>
-</h1>
+# facet-toml
 
-[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/facet-toml/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
 [![crates.io](https://img.shields.io/crates/v/facet-toml.svg)](https://crates.io/crates/facet-toml)
 [![documentation](https://docs.rs/facet-toml/badge.svg)](https://docs.rs/facet-toml)
 [![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/facet-toml.svg)](./LICENSE)
 [![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
 
-_Logo by [Misiasart](https://misiasart.com/)_
+Provides TOML serialization and deserialization for Facet types.
 
-Thanks to all individual and corporate sponsors, without whom this work could not exist:
+## Sponsors
 
-<p> <a href="https://ko-fi.com/fasterthanlime">
-<picture>
-<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/kofi-dark.svg">
-<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/kofi-light.svg" height="40" alt="Ko-fi">
-</picture>
-</a> <a href="https://github.com/sponsors/fasterthanlime">
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
 <picture>
 <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
 <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
 </picture>
 </a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
 <picture>
-<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
-<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
 </picture>
 </a> <a href="https://zed.dev">
 <picture>
@@ -44,7 +43,11 @@ Thanks to all individual and corporate sponsors, without whom this work could no
 </picture>
 </a> </p>
 
-Provides TOML serialization and deserialization for Facet types.
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
 
 ## License
 


### PR DESCRIPTION
This should help fix #7, and let application consumers update the rest of their facet deps while using `facet-toml`.

Few notes:
- The git hooks changed a few files outside of the code - I assume that's expected
- Looks like `facet-reflect` dropped `Partial::set_field_default`. From what I could tell, `Partial::set_nth_field_to_default` seemed like the best substitution in it's place (`Partial::set_default` doesn't use default functions passed in through field attributes), so I reshuffled the struct deserialisation a bit to use that instead. (I assume ultimately, this should all be replaced with `facet-deserialize`, but that's probably best left to another change.)